### PR TITLE
Fix failing pipelines PB-28

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -8,8 +8,15 @@ on:
 
 jobs:
   build:
+    container:
+      image: clojure
 
     runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
 
     steps:
     - uses: actions/checkout@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 version: '3.6'
+
+networks:
+  planning-bot:
+
 services:
   mongodb:
     image: mongo
-    ports:
-      - "27017:27017"
-    expose:
-      - "27017"
+    networks:
+      planning-bot:
 
   lein:
     image: clojure:lein
@@ -22,6 +24,10 @@ services:
       - "6662:6662"
       - "8080:8080"
     command: [ "lein", "repl", ":headless" ]
+    depends_on:
+      - mongodb
+    networks:
+      planning-bot:
 
 volumes:
   maven-cache:


### PR DESCRIPTION
# Description

This PR fixes the failing tests in GitHub pipelines. The solution includes specifying the Mongo service to be run alongside the pipeline so that the tested application can connect to working database. Since the URI of the tested database is [hardcoded here](https://github.com/makimo/name-microservice/blob/fix/failing-pipelines/test/name_service/storage.clj#L14), I needed to change the workflow to run the tests inside a container (see [this](https://github.com/makimo/name-microservice/blob/fix/failing-pipelines/.github/workflows/clojure.yml#L11)) so that the DB is accessible via hostname `mongodb` instead of `localhost`.

I've also took liberty of binding the containers in `docker-compose.yml` into bridged network instead of binding all the ports (ie. for Mongo) to the `localhost`: this fixes failures during local `lein test` runs.

## JIRA Issues

* [PB-28](https://makimo.atlassian.net/browse/PB-28)